### PR TITLE
Update golangci-lint workflow to improve caching and use latest versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,23 +8,39 @@ on:
 
 permissions:
   contents: read
-  # Optional: allow read access to pull requests. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
   golangci:
-    strategy:
-      matrix:
-        go: [stable]
-        os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version: latest
+
+      # Cache Go modules
+      - name: Cache Go Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # Optional: cache golangci-lint itself to speed up installs
+      - name: Cache golangci-lint
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-${{ hashFiles('.golangci.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: latest


### PR DESCRIPTION
- Simplified the workflow by removing the matrix strategy and setting a fixed OS to 'ubuntu-latest'.
- Updated Go version to 'latest' for consistency.
- Added caching for Go modules and golangci-lint to speed up the linting process.
- Updated golangci-lint action version to 'latest' for the most recent features and fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Streamlined linting pipeline for faster, more reliable checks by standardizing the environment and enabling caching for dependencies and linter assets.
  * Adopted latest toolchain versions to keep lint rules current and reduce maintenance.
  * Improved CI consistency and reduced variability across runs.
  * No impact on app behavior; builds and code-quality feedback should arrive quicker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->