### PR TITLE
Add Terraform configuration for ECR, IAM, and S3 resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 grafana.json
 test.js
 config.yaml
-global.tfvars
+globals.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 grafana.json
 test.js
 config.yaml
+global.tfvars

--- a/terraform/global/ecr/ecr.tf
+++ b/terraform/global/ecr/ecr.tf
@@ -1,0 +1,26 @@
+module "ecr" {
+  source  = "terraform-aws-modules/ecr/aws"
+  version = "3.1.0"
+
+  for_each = toset(var.github_repos)
+
+  repository_name = lower(each.key)
+
+  repository_lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1,
+        description  = "Keep last 30 images",
+        selection = {
+          tagStatus = "tagged",
+          tagPatternList : ["v"]
+          countType   = "imageCountMoreThan",
+          countNumber = 30
+        },
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/global/ecr/ecr.tf
+++ b/terraform/global/ecr/ecr.tf
@@ -1,6 +1,6 @@
 module "ecr" {
   source  = "terraform-aws-modules/ecr/aws"
-  version = "3.1.0"
+  version = "~> 3.1.0"
 
   for_each = toset(var.github_repos)
 
@@ -12,10 +12,10 @@ module "ecr" {
         rulePriority = 1,
         description  = "Keep last 30 images",
         selection = {
-          tagStatus = "tagged",
-          tagPatternList : ["v"]
-          countType   = "imageCountMoreThan",
-          countNumber = 30
+          tagStatus      = "tagged",
+          tagPatternList = ["v"]
+          countType      = "imageCountMoreThan",
+          countNumber    = 30
         },
         action = {
           type = "expire"

--- a/terraform/global/ecr/providers.tf
+++ b/terraform/global/ecr/providers.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region = var.region
+}
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/global/ecr/state.tf
+++ b/terraform/global/ecr/state.tf
@@ -1,0 +1,10 @@
+# TODO-uncomment this
+# terraform {
+#   backend "s3" {
+#     region       = ""
+#     bucket       = ""
+#     key          = "global/ecr/terraform.tfstate"
+#     use_lockfile = true
+#     encrypt      = true
+#   }
+# }

--- a/terraform/global/ecr/variables.tf
+++ b/terraform/global/ecr/variables.tf
@@ -1,0 +1,14 @@
+variable "region" {
+  type        = string
+  description = "AWS region to provision infrastructure."
+}
+
+variable "bucket" {
+  type        = string
+  description = "S3 bucket for terraform state."
+}
+
+variable "github_repos" {
+  type        = list(string)
+  description = "GitHub repositories."
+}

--- a/terraform/global/globals.tfvars
+++ b/terraform/global/globals.tfvars
@@ -1,0 +1,5 @@
+region = "us-east-1"
+bucket = "witty-terraform-state"
+github_repos = [
+  "yaninyzwitty/grpc-device-logging",
+]

--- a/terraform/global/iam/data.tf
+++ b/terraform/global/iam/data.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+

--- a/terraform/global/iam/iam_oidc.tf
+++ b/terraform/global/iam/iam_oidc.tf
@@ -1,0 +1,7 @@
+module "iam_oidc_provider" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-oidc-provider"
+  version = "6.2.1"
+
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+}

--- a/terraform/global/iam/iam_role.tf
+++ b/terraform/global/iam/iam_role.tf
@@ -1,0 +1,69 @@
+locals {
+  github_subs = [for item in var.github_repos : "repo:${item}:ref:refs/heads/*"]
+  ecr_repos   = [for item in var.github_repos : "arn:aws:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/${lower(item)}"]
+}
+
+module "iam_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.2.1"
+
+  name = "github-actions"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart"
+        ]
+        Resource = local.ecr_repos
+      },
+    ]
+  })
+}
+
+module "iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.2.1"
+
+  name = "github-actions"
+
+  use_name_prefix = false
+
+  trust_policy_permissions = {
+    TrustRoleAndServiceToAssume = {
+      actions = ["sts:AssumeRoleWithWebIdentity"]
+      principals = [{
+        type        = "Federated"
+        identifiers = [module.iam_oidc_provider.arn]
+      }]
+      condition = [{
+        test     = "StringEquals"
+        variable = "token.actions.githubusercontent.com:aud"
+        values   = ["sts.amazonaws.com"]
+        },
+        {
+          test     = "StringLike"
+          variable = "token.actions.githubusercontent.com:sub"
+          values   = local.github_subs
+        }
+      ]
+    }
+  }
+
+  policies = {
+    ECRReadWrite = module.iam_policy.arn
+  }
+}

--- a/terraform/global/iam/iam_role.tf
+++ b/terraform/global/iam/iam_role.tf
@@ -5,7 +5,7 @@ locals {
 
 module "iam_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.2.1"
+  version = "~> 6.2.1"
 
   name = "github-actions"
 
@@ -36,7 +36,7 @@ module "iam_policy" {
 
 module "iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.2.1"
+  version = "~> 6.2.1"
 
   name = "github-actions"
 

--- a/terraform/global/iam/output.tf
+++ b/terraform/global/iam/output.tf
@@ -1,0 +1,8 @@
+output "iam_oidc_provider_arn" {
+  description = "ARN of the IAM OIDC provider"
+  value       = module.iam_oidc_provider.arn
+}
+output "iam_role_arn" {
+  description = "ARN of the IAM role for GitHub Actions"
+  value       = module.iam_role.arn
+}

--- a/terraform/global/iam/providers.tf
+++ b/terraform/global/iam/providers.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region = var.region
+
+
+
+}
+
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/global/iam/state.tf
+++ b/terraform/global/iam/state.tf
@@ -1,0 +1,10 @@
+# TODO-uncomment this later
+# terraform {
+#   backend "s3" {
+#     region       = ""
+#     bucket       = ""
+#     key          = "global/iam/terraform.tfstate"
+#     use_lockfile = true
+#     encrypt      = true
+#   }
+# }

--- a/terraform/global/iam/variables.tf
+++ b/terraform/global/iam/variables.tf
@@ -1,0 +1,14 @@
+variable "region" {
+  type        = string
+  description = "AWS region to provision infrastructure."
+}
+
+variable "bucket" {
+  type        = string
+  description = "S3 bucket for terraform state."
+}
+
+variable "github_repos" {
+  type        = list(string)
+  description = "GitHub repositories."
+}

--- a/terraform/global/s3/output.tf
+++ b/terraform/global/s3/output.tf
@@ -1,0 +1,4 @@
+output "terraform_s3_bucket" {
+  value       = aws_s3_bucket.terraform_state.id
+  description = "An S3 bucket to store the Terraform state."
+}

--- a/terraform/global/s3/providers.tf
+++ b/terraform/global/s3/providers.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region = var.region
+}
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/global/s3/s3.tf
+++ b/terraform/global/s3/s3.tf
@@ -1,0 +1,43 @@
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = var.bucket
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+}
+
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+
+}
+
+
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+
+}
+
+
+
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket                  = aws_s3_bucket.terraform_state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+}

--- a/terraform/global/s3/state.tf
+++ b/terraform/global/s3/state.tf
@@ -1,0 +1,10 @@
+# terraform state
+# terraform {
+#   backend "s3" {
+#     region       = ""
+#     bucket       = ""
+#     key          = "global/s3/terraform.tfstate"
+#     use_lockfile = true
+#     encrypt      = true
+#   }
+# }

--- a/terraform/global/s3/variables.tf
+++ b/terraform/global/s3/variables.tf
@@ -1,0 +1,16 @@
+variable "region" {
+  type = string
+
+  description = "Aws region to provision the infrastracture"
+
+}
+
+variable "bucket" {
+  type        = string
+  description = "S3 bucket for terraform state."
+}
+
+variable "github_repos" {
+  type        = list(string)
+  description = "GitHub repositories."
+}

--- a/terraform/global/s3/variables.tf
+++ b/terraform/global/s3/variables.tf
@@ -1,7 +1,6 @@
 variable "region" {
-  type = string
-
-  description = "Aws region to provision the infrastracture"
+  type        = string
+  description = "AWS region to provision the infrastructure"
 
 }
 

--- a/terraform/global/state.config
+++ b/terraform/global/state.config
@@ -1,0 +1,2 @@
+region = "us-east-1"
+bucket = "witty-terraform-state"


### PR DESCRIPTION
- Introduced new files for ECR module, IAM roles, and S3 bucket management.
- Added variables for region, bucket, and GitHub repositories.
- Configured IAM OIDC provider and policies for GitHub Actions.
- Set up S3 bucket with versioning and encryption settings.
- Updated .gitignore to include new configuration files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Provisioned AWS ECR repositories with lifecycle rules to retain recent tagged images.
  * Added IAM OIDC provider and role to enable GitHub Actions access to ECR.
  * Created S3-backed Terraform state storage with versioning, encryption and access protections.
  * Added environment variable definitions for region, bucket and repo list, plus a globals vars file.
  * Updated .gitignore to exclude generated globals.tfvars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->